### PR TITLE
Some option settings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=eol=lf
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain


### PR DESCRIPTION
I followed the suggestion of the Github client and added its suggested
options. I think one of them was for suggested line endings. That was
probably a mistake as the client seemed to change the endings to cr/lf.
The option it selected was "text=auto" I have changed to "text=eol=lf"
which seems to have put the line endings back.

Moral of this story, be explicit about the line endings!
